### PR TITLE
bugfix prediction_glm.R newdata argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,10 @@ Authors@R: c(person("Thomas J.", "Leeper",
                     email = "thosjleeper@gmail.com",
                     comment = c(ORCID = "0000-0003-4097-6326")),
              person("Carl", "Ganz", role = "ctb",
-                    email = "carlganz@ucla.edu")
+                    email = "carlganz@ucla.edu"),
+             person("Vincent", "Arel-Bundock", role = "ctb",
+                    email = "vincent.arel-bundock@umontreal.ca",
+                    comment = c(ORCID = "0000-0003-2042-7063"))
             )
 URL: https://github.com/leeper/prediction
 BugReports: https://github.com/leeper/prediction/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# prediction 0.3.13
+
+* Fixed a bug in `prediction_glm` with the `data` argument (Issue #32).
+
 # prediction 0.3.12
 
 * Remove mnlogit dependency, as it has been removed from CRAN.

--- a/R/prediction_glm.R
+++ b/R/prediction_glm.R
@@ -51,7 +51,7 @@ function(model,
             if (type == "link") {
                 means_for_prediction <- colMeans(model_mat)
             } else if (type == "response") {
-                predictions_link <- predict(model, data = data, type = "link", se.fit = FALSE, ...)
+                predictions_link <- predict(model, newdata = data, type = "link", se.fit = FALSE, ...)
                 means_for_prediction <- colMeans(model$family$mu.eta(predictions_link) * model_mat)
             }
             J <- matrix(means_for_prediction, nrow = 1L)
@@ -64,7 +64,7 @@ function(model,
                 if (type == "link") {
                     means_for_prediction <- colMeans(model_mat)
                 } else if (type == "response") {
-                    predictions_link <- predict(model, data = one, type = "link", se.fit = FALSE, ...)
+                    predictions_link <- predict(model, newdata = one, type = "link", se.fit = FALSE, ...)
                     means_for_prediction <- colMeans(model$family$mu.eta(predictions_link) * model_mat)
                 }
                 means_for_prediction

--- a/tests/testthat/tests-core.R
+++ b/tests/testthat/tests-core.R
@@ -19,6 +19,16 @@ test_that("Test prediction()", {
                 label = "prediction() matches predict() (GLM)")
 })
 
+test_that("Test prediction(data = )", {
+    m <- lm(mpg ~ cyl + wt, data = mtcars)
+    p1 <- prediction(m, data = data.frame(cyl = 4, wt = 3.9))
+    expect_true(inherits(p1, "data.frame"), label = "prediction(lm(~), data = data.frame()) works")
+
+    m <- glm(mpg ~ cyl + wt, data = mtcars)
+    p1 <- prediction(m, data = data.frame(cyl = 4, wt = 3.9))
+    expect_true(inherits(p1, "data.frame"), label = "prediction(glm(~), data = data.frame()) works")
+})
+
 test_that("Test prediction(at = )", {
     m <- lm(mpg ~ cyl, data = mtcars)
     p1 <- prediction(m, at = list(cyl = 4))


### PR DESCRIPTION
This is a minor bugfix (with a new test) for: https://github.com/leeper/prediction/issues/32

I'm not sure how your version numbers work, so I just added a new entry to NEWS.

``` r
library(prediction)
data(mtcars)

# `data` with lm works
mod <- lm(am ~ hp + drat, data = mtcars)
prediction(mod, data = data.frame(hp = 110, drat = 3.9))
#> Data frame with 1 predictions from
#>  lm(formula = am ~ hp + drat, data = mtcars)
#> with average prediction: 0.5947

# `data` with glm doesn't work
mod <- glm(am ~ hp + drat, data = mtcars)
prediction(mod, data = data.frame(hp = 110, drat = 3.9))
#> Warning in model$family$mu.eta(predictions_link) * model_mat: longer object
#> length is not a multiple of shorter object length
#> Error in is.data.frame(x): dims [product 3] do not match the length of object [32]
```

This problem was caused by calling `predict(data = )` instead of `predict(newdata =` in a couple places in `prediction_glm.R`.

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/prediction/issues/new) first
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/prediction/blob/master/DESCRIPTION)
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/prediction/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/prediction/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

