### PR TITLE
Prevent data.table errors in check_values()

### DIFF
--- a/R/build_datalist.R
+++ b/R/build_datalist.R
@@ -89,6 +89,8 @@ check_factor_levels <- function(data, at) {
 
 check_values <- function(data, at) {
     # drop variables not in `at`
+    # first make sure any data.table is a data.frame to avoid error (for a data.table, this should include with=FALSE).
+    data <- as.data.frame(data)
     dat <- data[, names(at), drop = FALSE]
     
     # drop non-numeric variables from `dat` and `at`


### PR DESCRIPTION
check_values() relies on selecting variables using a vector of strings corresponding to names. If data is a data.table, this requires the option "with=FALSE". If we instead coerce data to a data.frame at the start of the function, we avoid this error.

This is a bugfix for issue #35.

Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/prediction/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/prediction/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/prediction/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/leeper/prediction/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

